### PR TITLE
New hire tips

### DIFF
--- a/docs/onboarding/new_member_tips.md
+++ b/docs/onboarding/new_member_tips.md
@@ -1,0 +1,114 @@
+# New Member Tips
+
+We have some recommendations for effective communications on the team. None of these recs are required, nor are they "one size fits all." You should determine which components are relevant for your work (and your team). At minimum, we believe these tips provide examples of good collaborating practices.
+
+## Project Check-in Meetings
+
+*When meeting with supervisors, here are some tips to keep things moving and build trust.*
+
+> **NOTE:** This section refers to meeting with supervisors about projects. Separately, we recommend finding time to chat 1:1 about personal growth, interests, and transparency. These 1:1s may benefit from a shared document to track notes and thoughts; however, those discussions probably don't benefit from the (more formal) recommendations below.
+
+Regular meetings with project supervisors are important to provide updates, address blockers, and elicit feedback. This is a lot to cover; typically, there's too much to discuss during the limited meeting time. To help organize project updates, we created [a slide template](https://docs.google.com/presentation/d/1FRSLc9K6z2stOXpcM7uPLf_43da_h2Q_Qy5sJxfnc4w/edit#slide=id.g3075ba84a90_0_0).
+
+The slide can be personalized and updated based on your needs. In this process, keep in mind the considerations that the template emphasizes:
+
+- **Priorities:** Which projects and tasks are you responsible or accountable for?
+	- Communicated on the slide by laying out a main project list (rows in table).
+- **Synthesized call-outs:** In a time-limited meeting, what are the “big” ideas or need-to-knows?
+	- This is the "call-outs" column in the slide.
+- **Time commitments:** How much time do the projects and tasks currently demand?
+	- “Status” column contains an opportunity to call out % time.
+- **Status:** How are things progressing?
+	- Set a status to good (green), uncertain or behind schedule (yellow), or blocked (red).
+- **Feedback:** Being prepared to track action items or recs during the meeting.
+	- "Meeting Comments" column in the slide track notes in real time.
+- ***BONUS:*** When concrete tasks and timelines are decided during the meeting, we recommend summarizing and sending these the meeting participants afterward.
+	- This helps track decisions, and confirm understanding for the next steps.
+
+## Schedule Meetings
+
+*To save time finding time.*
+
+- **Prompting a meeting:** If you've not discussed a new meeting, I'd typically recommend sending a brief note proposing a meeting and its context (see "Email Tips"). In your message, you can (a) indicate that they should expect an invite from you shortly, or (b) provide times based on your availability. More info on these options are below.
+- **Offering times:** If the invitees are external and don’t have assistants to help schedule time, consider using [Microsoft Bookings](https://outlook.office.com/bookings/homepage) to share your availability. This tool’s available through Yale's Microsoft Office Suite, and it stays up-to-date with your Outlook calendar.
+	- Preferably, create a "Personal booking page" with the length of the desired meeting. You can also set preferences for days or times (beyond your calendar availability). Then copy the link to the booking page and share with your partners.
+	- Not only does Bookings allow you to share your availability, it also lets the other party schedule immediately based on their availability.
+- **Proposing times:** If you’re meeting with people from Yale, use "Scheduling Assistant" in Outlook to find available times. (1) Create a new meeting in your calendar, (2) add invitees, (3) click on "Scheduling Assistant" in the top bar, and (4) find a time that’s available for everyone.
+- **Agenda:** Whenever scheduling a meeting, it is highly recommended to include an agenda. This can be helpful for invitees ... but it's even more important for you as the scheduler. This requires you to reflect on the goals for the meeting: what needs to be covered and what are you trying to accomplish by the end of the meeting?
+	- Several times, I've been close to scheduling the meeting ... but when writing the agenda realized that an email would suffice.
+
+### Example 1: Original scheduling
+
+> Hi team,
+> 
+> We discussed needing additional time on Thursday or Friday to chat before the big deadline. Just let me know which times work for you all, then I can send a Zoom link.
+> 
+> Thanks!
+> Lab_Staff
+
+### Example 2: Revised scheduling
+
+> Hi team,
+> 
+> Based on everyone's availability, it looks like this time might work well on Thursday. Let me know if you'd prefer a different time.
+> 
+> Please find the agenda and Zoom link below.
+> 
+> Thanks!
+> Lab_Staff
+> 
+> ***Agenda***
+> - Review proposed edits
+> - Create timeline to finalize draft
+> - Delegate remaining tasks
+
+## Email Tips
+
+*This checklist aims to improve team communication … and help you get responses quicker!*
+
+- **Context:** Briefly (1-2 sentences) reintroduce the project or task if recipients have not recently discussed the matter
+- **Intent:** Make explicit the goal of the message - request, question, or FYI
+	- For requests, if there are multiple email recipients involved in different aspects of the request, specify what is requested from each individual (e.g., tag "@" each requestee)
+- **Timeline:** If needed, state whether a response is urgent or not and propose a timeline to resolve requests or questions (while being courteous of others' priorities and availability!)
+- **Proposals:** Whenever raising complexities or barriers, present potential solutions that the team might consider. These likely belong in the postscript section (see "Details"). Note the proposal doesn't need to be perfect; for example, if you don’t have enough context to provide a resolution, you might propose meeting with someone to gather more information as a next step.
+- **Attachments:** Specify any attachments (sometimes by name if there are multiple files).
+	- If possible (e.g., internal emails with non-sensitive documents), opt to link to a centralized document in Google Drive or Dropbox rather than sending flat files.
+- **Details:** For any additional info beyond the core components above, create a separate postscript section after your signature. This helps recipients (1) first understand what’s needed, then (2) refer back to the postscript when setting aside time to address the need.
+
+### Example 1: Original email
+
+> Hi team,
+> 
+> I’ve run into data issues in the past few days. Does anyone know why I receive the error "ORA-10023 Index out of Bounds" when using the MCO data? There’s also the issue of the data formatting in the extracts we received. It’s not allowing me to identify paid dates, which are important for looking at trends like the team requested.
+> 
+> Here's a screenshot of the error: (Screenshot.png)
+> 
+> Here's what the data looks like in its raw form. (Notice that the paid dates are encoded weirdly.) (Table)
+> 
+> I still tried to run some early analyses (see attached Excel), but I'm skeptical of the results because of these issues.
+> 
+> Any thoughts on where to go from here?
+> 
+> Thank you in advance!
+> Lab_Staff
+
+### Example 2: Revised email
+
+> Hi team,
+> 
+> For the MCO Project, we had discussed analyzing trends in medical spend. I started pulling data, but encountered some barriers recently (details below). I'm hoping to get some support this week to address the issues.
+> 
+> @Colleague_1 with your experience with the data and domain, can you do a 10-15min sanity check of the preliminary findings linked here? Hoping to get feedback by end-of-week if possible, but let me know if that wouldn't work.
+> 
+> @Colleague_2 can we set up a peer coding session to identify any programming errors? If you’re open to it, I can send an invite based on your calendar availability over the next couple days.
+> 
+> Thank you in advance!
+> Lab_Staff
+> 
+> +++
+> 
+> *Problem details*
+> - **Issue #1:** The data processing pipeline is failing when I try to merge MCO extracts. Specifically, it’s this line (Github link) with an error: "..."
+> - **Issue #2:** Formatting in the raw MCO data extract ("file_path.csv") has paid dates with an undefined encoding, which keeps me from running a trend analysis. See a data example below.
+> (Table)
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,6 +22,7 @@ nav:
   - Home: index.md
   - Onboarding:
     - New Member Onboarding: onboarding/new_member_onboarding.md
+    - New Member Tips: onboarding/new_member_tips.md
   - Data Science:
     - Connecting to the Server: data_science/server_connect.md
     - Project Organization: data_science/project_organization.md


### PR DESCRIPTION
Moving lab-wide communication tips out of Google Drive and into the Github Pages documentation.

This PR makes 1 change:

1. Include a "New Member Tips" page in the "Onboarding" section. The new page is linked in the `nav` section of the YAML site configuration.