### PR TITLE
Open Data Repos

### DIFF
--- a/docs/data_science/open_data_resources.md
+++ b/docs/data_science/open_data_resources.md
@@ -1,0 +1,15 @@
+# Open Data Resources
+
+The references below offer classifications and registries to augment analyses.
+
+| Open Data Resource | Purpose |
+| --- | --- |
+| [Avoidable Emergency Department (ED)](https://wagner.nyu.edu/faculty/billings/nyued-background) | Algorithm developed by NYU to classify ED visits into Non-emergent; Emergent/Primary Care Treatable; Emergent (ED Care Needed), Preventable/Avoidable; Emergent (ED Care Needed), Not Preventable/Avoidable. |
+| [Chronic Condition Warehouse (CCW)](https://www2.ccwdata.org/web/guest/condition-categories-chronic) | The CCW groups diagnosis codes into well-known categories, such as Diabetes or Hypertension. There are 30 conditions in total. |
+| [Clinical Classifications Software (CCS)](https://hcup-us.ahrq.gov/toolssoftware/ccs10/ccs10.jsp) | ICD-10-CM procedure grouper with 224 classifications. |
+| Diagnosis-Related Groups (DRG) | Diagnosis groupers, which are used to decide case mix for Medicare reimbursements. |
+| [Healthcare Effectiveness Data & Information Set (HEDIS)](https://www.ncqa.org/hedis/measures/) | Performance quality with >90 measures ranging from Effectiveness of Care, Access/Availability of Care, Experience of Care, Utilization & Risk Adjusted Utilization, Health Plan Descriptive Information, and Measures Reported Using Electronic Clinical Data Systems. |
+| [National Drug Code (NDC)](https://www.fda.gov/drugs/drug-approvals-and-databases/national-drug-code-directory) | Registry for drugs approved by the FDA. |
+| [National Plan & Provider Enumeration System (NPPES)](https://www.nber.org/research/data/national-plan-and-provider-enumeration-system-nppes) | Provider (and provider organization) registry developed by CMS. |
+| [Prevention Quality Indicators (PQI)](https://qualityindicators.ahrq.gov/measures/PQI_TechSpec) | Inpatient quality measures that "use data from hospital discharges to identify admissions that might have been avoided through access to high-quality outpatient care." |
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,7 @@ nav:
       - R Virtual Environments: data_science/venv/r_venv.md
     - Coding Conventions: data_science/coding_conventions.md 
     - State Medicaid Data: data_science/state_medicaid_data.md
+    - Open Data Resources: data_science/open_data_resources.md
   - T-MSIS: 
     - T-MSIS Overview: tmsis/tmsis_medicaid_data.md
     - Working on Milgram: tmsis/tmsis_getting_started.md


### PR DESCRIPTION
Tracking a list of the (main) public-access data repos the team uses.

This PR makes 1 change:

1. Include a "Open Data Resources" page in the "Data Science" section. The new page is linked in the nav section of the YAML site configuration.