### PR TITLE
Initialize embedded onboarding docs

### DIFF
--- a/docs/embedding/onboarding.md
+++ b/docs/embedding/onboarding.md
@@ -1,0 +1,24 @@
+# Embedding Onboarding
+
+Most information related to embedded systems will be tracked within the embedded portal (virtual machine). Below, we track how to establish a VM connection and debug any administrative issues.
+
+| Support Team | Contact Info | When to use |
+| --- | --- | --- |
+| DSS IT Support | 860-424-4949; DSS-ITS-Support@ct.gov | Locked out of portal, password issues, questions about online IT tickets, ... |
+| DSS Security | While in-person, ask to call the 2nd floor security to fix badge access | Issues accessing Hartford Central Office in-person |
+
+## Azure Virtual Desktop (AVD)
+
+The Connecticut DSS embedded portal is based out of an AVD instance. You must go through the following process to obtain online access:
+
+1. Have a team manager submit a DSS request for credentials
+2. Install the "Microsoft Authenticator" application on your phone for 2-factor authentication
+3. Install "Microsoft Remote Desktop" from the App Store
+    - Upon launch, click the "Microsoft Remote Desktop > Preferences..." button on the upper right console and unclick "Enable optimizations for Microsoft Teams"
+    - Go to "Connections > Add Workspace" and use the following URL: https://rdweb.wvd.microsoft.com/api/arm/feeddiscovery
+    - Use your state credentials (@ct.gov) to log in, including 2-factor authentication
+4. Reset your password
+    - Directly from the VM display (Ctrl+Alt+Delete, or Ctrl+Opt+Delete on Mac)
+    - Alternatively, try going to office.com in the browser, logging in with your state credentials, and selecting "Change password" from the settings icon
+
+

--- a/docs/embedding/onboarding.md
+++ b/docs/embedding/onboarding.md
@@ -18,7 +18,21 @@ The Connecticut DSS embedded portal is based out of an AVD instance. You must go
     - Go to "Connections > Add Workspace" and use the following URL: https://rdweb.wvd.microsoft.com/api/arm/feeddiscovery
     - Use your state credentials (@ct.gov) to log in, including 2-factor authentication
 4. Reset your password
+    - Review password requirements in the section below
     - Directly from the VM display (Ctrl+Alt+Delete, or Ctrl+Opt+Delete on Mac)
     - Alternatively, try going to office.com in the browser, logging in with your state credentials, and selecting "Change password" from the settings icon
 
+## Password Requirements
+
+Connecticut DSS security requires the following password requirements:
+
+- Must be at least 9 characters long
+- Must contain at least one character in 3 of the following groups of characters:
+    - Uppercase letters (A-Z)
+    - Lowercase letters (a-z)
+    - Numbers (0-9)
+    - Symbols (!@#$%^&*)
+- Cannot match any of your previous 24 passwords
+- Avoid using single words that can be found in the dictionary (e.g., "Wintertime1!")
+- You cannot change your password more often than once in a 7-day period unless overridden by the helpdesk
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,7 @@ nav:
       - Identifying Providers and Facilities: tmsis/vignettes/providers.md
   - Embedding:
     - Guidebook: embedding/guidebook.md
+    - Onboarding: embedding/onboarding.md
   - Project Links: project_links.md
 
 


### PR DESCRIPTION
Initializing high-level onboarding directions for Connecticut partnership.

This PR makes 1 change:

- Include an initial "Embedding Onboarding" page. The new page is linked in the nav section of the YAML site configuration.

Confirmed the rendering using local mkdocs build.